### PR TITLE
Update keep alive packet ids

### DIFF
--- a/src/packet.ts
+++ b/src/packet.ts
@@ -3,14 +3,9 @@ import * as nbt from "nbt-ts"
 
 export type Packet = PacketReader | PacketWriter | Buffer
 
-const V_1_16_3 = 753
-const V_1_15 = 573
-const V_1_14 = 477
-const V_1_13 = 393
-
 export const getPacketIdMap = (v: number) => ({
-    keepAliveC: v < V_1_16_3 ? v < V_1_15 ? v < V_1_14 ? v < V_1_13 ? 0x1f : 0x21 : 0x20 : 0x21 : 0x1f,
-    keepAliveS: v < V_1_16_3 ? v < V_1_14 ? v < V_1_13 ? 0xb : 0xe : 0xf : 0x10
+    keepAliveC: v < 751 ? v < 573 ? v < 477 ? v < 393 ? v < 107 ? 0x0 : 0x1f : 0x21 : 0x20 : 0x21 : 0x1f,
+    keepAliveS: v < 735 ? v < 477 ? v < 393 ? v < 107 ? 0x0 : 0xb : 0xe : 0xf : 0x10
 })
 
 export interface Position {


### PR DESCRIPTION
Based on the following data extracted from https://github.com/PrismarineJS/minecraft-data from full releases only. Snapshots and prereleases were not included to avoid complexity because either packet ids were changing from version to version or upstream data is wrong.
**EDIT:** Also fixes ids for 1.7/1.8.
```js
keepAliveC {
  '1.7': '1.7.2 / 4 / 0x00',
  '1.9': '1.9 / 107 / 0x1f',
  '1.13': '1.13 / 393 / 0x21',
  '1.14': '1.14 / 477 / 0x20',
  '1.15': '1.15 / 573 / 0x21',
  '1.16': '1.16.2 / 751 / 0x1f'
}
keepAliveS {
  '1.7': '1.7.2 / 4 / 0x00',
  '1.9': '1.9 / 107 / 0x0b',
  '1.12': '1.12.1 / 338 / 0x0b',
  '1.13': '1.13 / 393 / 0x0e',
  '1.14': '1.14 / 477 / 0x0f',
  '1.16': '1.16 / 735 / 0x10'
}
```